### PR TITLE
BerryLan Mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # pi-gen
 
-_Tool used to create the raspberrypi.org Raspbian images_
+_Tool used to create the berrylan.app Raspbian images_
 
+This tool is based on the pi-gen tool of the raspberrypi.org Raspbian images.
+It only adds http://repository.nymea.io to the repositories and preinstalls
+nymea-networkmanager in the image to allow WiFi configuration via BerryLan.
+
+nymea-networkmanager can be found at https://github.com/guh/nymea-networkmanager
 
 ## Dependencies
 

--- a/stage2/00-packages/00-run-chroot.sh
+++ b/stage2/00-packages/00-run-chroot.sh
@@ -1,0 +1,16 @@
+# Add nymea repository
+echo -e "\n## nymea repo\ndeb http://repository.nymea.io stretch main raspbian\n#deb-src http://repository.nymea.io stretch main raspbian" | tee /etc/apt/sources.list.d/nymea.list
+wget -qO - http://repository.nymea.io/repository-pubkey.gpg | apt-key add -
+
+# Set repository priority (prefere packages from raspbian section
+cat <<EOM >/etc/apt/preferences.d/nymea
+Package: *
+Pin: release c=raspbian
+Pin-Priority: 700
+
+Package: *
+Pin: origin repository.nymea.io c=main
+Pin-Priority: 500
+EOM
+
+apt-get update

--- a/stage2/00-packages/01-packages
+++ b/stage2/00-packages/01-packages
@@ -1,0 +1,1 @@
+nymea-networkmanager

--- a/stage2/02-net-tweaks/00-packages
+++ b/stage2/02-net-tweaks/00-packages
@@ -1,4 +1,4 @@
 wpasupplicant wireless-tools firmware-atheros firmware-brcm80211 firmware-libertas firmware-misc-nonfree firmware-realtek
 raspberrypi-net-mods
-dhcpcd5
 net-tools
+network-manager

--- a/stage2/02-net-tweaks/01-run-chroot.sh
+++ b/stage2/02-net-tweaks/01-run-chroot.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+systemctl enable ssh
+systemctl disable dhcpcd5

--- a/stage2/02-net-tweaks/01-run.sh
+++ b/stage2/02-net-tweaks/01-run.sh
@@ -1,8 +1,6 @@
 #!/bin/bash -e
 
-install -v -d					"${ROOTFS_DIR}/etc/systemd/system/dhcpcd.service.d"
-install -v -m 644 files/wait.conf		"${ROOTFS_DIR}/etc/systemd/system/dhcpcd.service.d/"
-
 install -v -d					"${ROOTFS_DIR}/etc/wpa_supplicant"
 install -v -m 600 files/wpa_supplicant.conf	"${ROOTFS_DIR}/etc/wpa_supplicant/"
 
+sed -i 's/-a nymea -p nymea-box/-a "Raspberry Pi" -p "Raspberry Pi"/' ${ROOTFS_DIR}/lib/systemd/system/nymea-networkmanager.service


### PR DESCRIPTION
*Do not merge into master. This is just to show a diff between upstream Raspbian and berrylan mods.*

* replace dhcpcd5 with network-manager
* seed in the nymea repository and nymea-networkmanager
* patch nymea-networkmanager startup comand to use "Raspberry Pi" instead of nymea